### PR TITLE
remove idle_timeout override as cowboy 1.x handles idle timeout and s…

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,7 @@ config :discovery_api, DiscoveryApiWeb.Endpoint,
   render_errors: [view: DiscoveryApiWeb.ErrorView, accepts: ~w(json)],
   pubsub: [name: DiscoveryApi.PubSub, adapter: Phoenix.PubSub.PG2],
   instrumenters: [DiscoveryApiWeb.Endpoint.Instrumenter],
-  http: [port: 4000, protocol_options: [idle_timeout: 7_200_000]]
+  http: [port: 4000]
 
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",


### PR DESCRIPTION
…treaming differently than 2.x

smartcitiesdata/discovery-api#

co-authored-by: Jessie Morris <jmorris2@pillartechnology.com>